### PR TITLE
few tweaks for clarity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,2 @@
 script:
-    - ./travis-tests.sh
+    - bash travis-tests.sh

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $ bash mytests.sh
 To run only certain tests, use:
 
 ```
-base mytests.sh test_for_success test_42
+$ bash mytests.sh test_for_success test_42
 ```
 
 

--- a/example_tests.sh
+++ b/example_tests.sh
@@ -37,6 +37,7 @@ assert_in_stderr "simple test"
 # Success
 run test_stdout python -c "print 'example assert_stdout success'"
 assert_stdout 
+
 # Fails because there is nothing in stdout
 run test_stdout python -c "import sys; sys.stderr.write('example assert_stdout failure')"
 assert_stdout 
@@ -54,6 +55,7 @@ assert_stderr
 # Success
 run test_no_stdout python -c "import sys; sys.stderr.write('example assert_no_stdout success')"
 assert_no_stdout 
+
 # Fails because there is something in stdout
 run test_no_stdout python -c "print 'example assert_no_stdout failure'"
 assert_no_stdout 
@@ -62,6 +64,7 @@ assert_no_stdout
 # Success
 run test_no_stderr python -c "print 'example assert_no_stderr success'"
 assert_no_stderr 
+
 # Fails because there is something in stderr
 run test_no_stderr python -c "import sys; sys.stderr.write('example assert_no_stderr failure')"
 assert_no_stderr 
@@ -70,8 +73,10 @@ assert_no_stderr
 # Success
 run test_exit_code python -c "print 1;"
 assert_exit_code $EX_OK 
+
 run test_exit_code python -c "import sys; sys.exit(66);"
 assert_exit_code $EX_NOINPUT 
+
 # Fails because the error code is wrong
 run test_exit_code python -c "import sys; sys.exit(66);"
 assert_exit_code $EX_USAGE 
@@ -81,6 +86,7 @@ assert_exit_code $EX_USAGE
 touch test.out
 run test_equal python -c "f = open('test.out','w'); f.write('1\n2\n3\n');f.close();"
 assert_equal "$(cat test.out | wc -l)" 3 
+
 run test_equal python -c "f = open('test.out','w'); f.write('1\n2\n3\n');f.close();"
 # Failure
 assert_equal "$(cat test.out | wc -l)" 4 

--- a/example_tests.sh
+++ b/example_tests.sh
@@ -2,86 +2,86 @@
 
 test -e ssshtest || wget -q https://raw.githubusercontent.com/ryanlayer/ssshtest/master/ssshtest
 
-. ssshtest
+source ssshtest
 
 STOP_ON_FAIL=0
 
 #--- assert_in_stdout
 # Success
-run assert_in_stdout python -c "print 'example assert_in_stdout success'"
+run test_in_stdout python -c "print 'example assert_in_stdout success'"
 assert_in_stdout "example"
 
 # Fails because there is nothing in stdout
-run assert_in_stdout python -c "import sys; sys.stderr.write('example assert_in_stdout failure')"
+run test_in_stdout python -c "import sys; sys.stderr.write('example assert_in_stdout failure')"
 assert_in_stdout "example"
 
 # Fails because "simple test" is not in stdout
-run assert_in_stdout python -c "print 'example assert_in_stdout success'"
+run test_in_stdout python -c "print 'example assert_in_stdout success'"
 assert_in_stdout "simple test"
 
 
 #--- assert_in_stderr
 # Success
-run assert_in_stderr python -c "import sys; sys.stderr.write('example assert_in_stderr success')"
+run test_in_stderr python -c "import sys; sys.stderr.write('example assert_in_stderr success')"
 assert_in_stderr "example" 
 
 # Fails because there is nothing in stderr
-run assert_in_stderr python -c "print 'example assert_in_stderr failure'"
+run test_in_stderr python -c "print 'example assert_in_stderr failure'"
 assert_in_stderr "example" 
 
 # Fails because "simple test" is not in stderr
-run assert_in_stderr python -c "import sys; sys.stderr.write('example assert_in_stderr success')"
+run test_in_stderr python -c "import sys; sys.stderr.write('example assert_in_stderr success')"
 assert_in_stderr "simple test" 
 
 #--- assert_stdout
 # Success
-run assert_stdout python -c "print 'example assert_stdout success'"
+run test_stdout python -c "print 'example assert_stdout success'"
 assert_stdout 
 # Fails because there is nothing in stdout
-run assert_stdout python -c "import sys; sys.stderr.write('example assert_stdout failure')"
+run test_stdout python -c "import sys; sys.stderr.write('example assert_stdout failure')"
 assert_stdout 
 
 #--- assert_stderr
 # Success
-run assert_stderr python -c "import sys; sys.stderr.write('example assert_stderr success')"
+run test_stderr python -c "import sys; sys.stderr.write('example assert_stderr success')"
 assert_stderr 
 
 # Fails because there is nothing in stderr
-run assert_stderr python -c "print 'example assert_stderr failure'"
+run test_stderr python -c "print 'example assert_stderr failure'"
 assert_stderr 
 
 #assert_no_stdout
 # Success
-run assert_no_stdout python -c "import sys; sys.stderr.write('example assert_no_stdout success')"
+run test_no_stdout python -c "import sys; sys.stderr.write('example assert_no_stdout success')"
 assert_no_stdout 
 # Fails because there is something in stdout
-run assert_no_stdout python -c "print 'example assert_no_stdout failure'"
+run test_no_stdout python -c "print 'example assert_no_stdout failure'"
 assert_no_stdout 
 
 #-- assert_no_stderr
 # Success
-run assert_no_stderr python -c "print 'example assert_no_stderr success'"
+run test_no_stderr python -c "print 'example assert_no_stderr success'"
 assert_no_stderr 
 # Fails because there is something in stderr
-run assert_no_stderr python -c "import sys; sys.stderr.write('example assert_no_stderr failure')"
+run test_no_stderr python -c "import sys; sys.stderr.write('example assert_no_stderr failure')"
 assert_no_stderr 
 
 #--assert_exit_code
 # Success
-run assert_exit_code python -c "print 1;"
+run test_exit_code python -c "print 1;"
 assert_exit_code $EX_OK 
-run assert_exit_code python -c "import sys; sys.exit(66);"
+run test_exit_code python -c "import sys; sys.exit(66);"
 assert_exit_code $EX_NOINPUT 
 # Fails because the error code is wrong
-run assert_exit_code python -c "import sys; sys.exit(66);"
+run test_exit_code python -c "import sys; sys.exit(66);"
 assert_exit_code $EX_USAGE 
 
 #assert_equal
 # Success
 touch test.out
-run assert_equal python -c "f = open('test.out','w'); f.write('1\n2\n3\n');f.close();"
+run test_equal python -c "f = open('test.out','w'); f.write('1\n2\n3\n');f.close();"
 assert_equal "$(cat test.out | wc -l)" 3 
-run assert_equal python -c "f = open('test.out','w'); f.write('1\n2\n3\n');f.close();"
+run test_equal python -c "f = open('test.out','w'); f.write('1\n2\n3\n');f.close();"
 # Failure
 assert_equal "$(cat test.out | wc -l)" 4 
 rm -f test.out

--- a/travis-tests.sh
+++ b/travis-tests.sh
@@ -2,7 +2,7 @@
 
 test -e ssshtest || wget -q https://raw.githubusercontent.com/ryanlayer/ssshtest/master/ssshtest
 
-. ssshtest
+source ssshtest
 
 set -o nounset
 


### PR DESCRIPTION
Few changes:
- Remove use of `.` bash function for `source`. 
- Call `bash .travis-tests.sh` instead of direct execution. It surprised me that the test file had to be executable. And your classifier for badge status still works ;)
- I suggest adopting the following layout:

``` bash
# clear
run test_not_equal
assert_not_equal

# not
run assert_not_equal
assert_not_equal
```

You had a few tests named `assert_XXX` and that was confusing.
