### PR TITLE
fixed newline bug in assert_true

### DIFF
--- a/ssshtest
+++ b/ssshtest
@@ -501,7 +501,7 @@ function assert_true {
 
     COMMAND=("$@")
     RES=`${COMMAND[@]}`
-    echo $RES || "AAAAAAAAAAA"
+    echo $RES > /dev/null 2>&1 || "AAAAAAAAAAA"
 
     if [ "$FLAG" -eq 0 ];then return; fi
 


### PR DESCRIPTION
in function assert_true, RES evaluates the command being run. 
RES is then echoed in line 504 to check if the command runs successfully. This prints  the output to stdout, if RES doesn't have any output, it prints a newline to stdout which is undesired. 

the output of the command is now piped into /dev/null so the output doesn't show up on stdout. 